### PR TITLE
Add WordPress API integration to ARTS AND ENTERTAINMENT section

### DIFF
--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -27,11 +27,13 @@
   grid-template-columns: 1fr 1fr 1fr;
   gap: 40px;
   margin-bottom: 40px;
+  align-items: stretch;
 }
 
 .footer-section {
   display: flex;
   flex-direction: column;
+  height: 100%;
 }
 
 .footer-title {

--- a/src/components/Homepage/Homepage.css
+++ b/src/components/Homepage/Homepage.css
@@ -260,6 +260,11 @@
   color: #666;
   line-height: 1.4;
   margin: 0 0 10px 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .article-meta {

--- a/src/components/Homepage/index.tsx
+++ b/src/components/Homepage/index.tsx
@@ -7,6 +7,7 @@ import './Homepage.css';
 const Homepage: React.FC<HomepageProps> = ({ className = '' }) => {
   const [featuredArticles, setFeaturedArticles] = useState<SlideData[]>([]);
   const [newsArticles, setNewsArticles] = useState<Article[]>([]);
+  const [artsArticles, setArtsArticles] = useState<Article[]>([]);
   const [loading, setLoading] = useState(true);
 
   // Fallback data
@@ -97,9 +98,12 @@ const Homepage: React.FC<HomepageProps> = ({ className = '' }) => {
         // Start with fallback data immediately
         setFeaturedArticles(fallbackFeaturedArticles);
         setNewsArticles(fallbackNewsArticles);
+        setArtsArticles(fallbackArtsArticles);
         setLoading(false);
         
         const newsService = new WordPressNewsService();
+        
+        // Fetch general news
         const wpArticles = await newsService.getLatestNewsForSlider(9);
         
         if (wpArticles && wpArticles.length > 0) {
@@ -110,6 +114,30 @@ const Homepage: React.FC<HomepageProps> = ({ className = '' }) => {
         } else {
           console.warn('No WordPress articles found, keeping fallback data');
         }
+
+        // Fetch arts and entertainment articles
+        try {
+          const artsArticles = await newsService.getLatestNewsByCategory('arts-entertainment', 4);
+          if (artsArticles && artsArticles.length > 0) {
+            const transformedArtsArticles: Article[] = artsArticles.map(article => ({
+              id: article.id,
+              title: article.title,
+              date: article.date,
+              image: article.image,
+              excerpt: article.excerpt,
+              comments: 0,
+              category: article.category
+            }));
+            setArtsArticles(transformedArtsArticles);
+            console.log('Successfully loaded WordPress arts articles:', artsArticles.length);
+          } else {
+            console.warn('No WordPress arts articles found, keeping fallback data');
+          }
+        } catch (artsError) {
+          console.error('Error loading WordPress arts articles:', artsError);
+          // Keep fallback arts data
+        }
+        
       } catch (error) {
         console.error('Error loading WordPress news:', error);
         // Keep fallback data that's already set
@@ -119,7 +147,7 @@ const Homepage: React.FC<HomepageProps> = ({ className = '' }) => {
     fetchNewsData();
   }, []);
 
-  const artsArticles: Article[] = [
+  const fallbackArtsArticles: Article[] = [
     {
       id: 1,
       title: "REVIEW: SKANK SINATRA AT QTOPIA, DARLINGHURST",


### PR DESCRIPTION
## Summary
- Integrated WordPress API for ARTS AND ENTERTAINMENT section using existing WordPressNewsService
- Added dynamic fetching of articles from 'arts-entertainment' category with graceful fallback
- Fixed footer alignment issues by implementing equal heights across all three footer sections
- Limited article excerpts to 3 rows using CSS overflow properties for consistent presentation

## Test plan
- [x] Verify ARTS AND ENTERTAINMENT section loads WordPress articles
- [x] Test fallback functionality when API is unavailable
- [x] Confirm footer sections have equal heights
- [x] Check article excerpts are properly truncated to 3 lines
- [ ] Test responsive design on mobile devices
- [ ] Verify no console errors in browser

🤖 Generated with [Claude Code](https://claude.ai/code)